### PR TITLE
Remove ArrayList boxing

### DIFF
--- a/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
+++ b/heron/api/src/java/com/twitter/heron/api/utils/Utils.java
@@ -21,7 +21,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +34,7 @@ public final class Utils {
 
   public static List<Object> tuple(Object... values) {
     List<Object> ret = new ArrayList<>();
-    Collections.addAll(ret, Arrays.asList(values));
+    Collections.addAll(ret, values);
     return ret;
   }
 


### PR DESCRIPTION
Arrays.asList() returns a private inner class implementation of
ArrayList(http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/Arrays.java#3355).
This class is not register with kryo by default and it is a tedious to
do so. The fallout of this is that anyone who uses the RawScheme will
receive the following exception:

`java.lang.RuntimeException: java.lang.IllegalArgumentException: Class
is not registered: java.util.Arrays$ArrayList`