### PR TITLE
Don't keep STDIN open if not attached

### DIFF
--- a/docker/build-artifacts.sh
+++ b/docker/build-artifacts.sh
@@ -90,18 +90,13 @@ verify_source_exists() {
 }
 
 setup_scratch_dir() {
-  if [ ! -f "$1" ]; then
-    mkdir $1
-  fi
-
+  mkdir -p $1
   cp $DOCKER_DIR/* $1
 }
 
 setup_output_dir() {
-  if [ ! -d $1 ]; then
-    echo "Creating output directory $1"
-    mkdir $1
-  fi
+  echo "Creating output directory $1"
+  mkdir -p $1
 }
 
 run_build() {

--- a/docker/compile-docker.sh
+++ b/docker/compile-docker.sh
@@ -47,4 +47,4 @@ docker run \
     -e HERON_TREE_STATUS="${HERON_TREE_STATUS}" \
     -v "$SOURCE_TARBALL:/src.tar.gz:ro" \
     -v "$OUTPUT_DIRECTORY:/dist" \
-    -it heron-compiler:$TARGET_PLATFORM /compile-platform.sh
+    -t heron-compiler:$TARGET_PLATFORM /compile-platform.sh


### PR DESCRIPTION
The `-i` argument for docker keeps STDIN open even when the container is
not attached. In some ci environments this will likely by the case and
result in this error: `cannot enable tty mode on non tty input`

This also changes the scratch and output directory creation to use `-p`
so it will both create the whole path and not fail if the directory
exists.