### PR TITLE
Print topology resources to console

### DIFF
--- a/heron/cli/src/python/main.py
+++ b/heron/cli/src/python/main.py
@@ -33,6 +33,7 @@ import heron.cli.src.python.restart as restart
 import heron.cli.src.python.submit as submit
 import heron.common.src.python.utils.config as config
 import heron.cli.src.python.version as version
+import heron.cli.src.python.resources as resources
 
 HELP_EPILOG = '''Getting more help:
   heron help <command> Prints help and options for <command>
@@ -95,6 +96,7 @@ def create_parser():
   restart.create_parser(subparsers)
   submit.create_parser(subparsers)
   version.create_parser(subparsers)
+  resources.create_parser(subparsers)
 
   return parser
 
@@ -131,8 +133,10 @@ def run(command, parser, command_args, unknown_args):
   elif command == 'version':
     status = version.run(command, parser, command_args, unknown_args)
 
-  return status
+  elif command == 'resources':
+    status = resources.run(command, parser, command_args, unknown_args)
 
+  return status
 
 def cleanup(files):
   '''

--- a/heron/cli/src/python/resources.py
+++ b/heron/cli/src/python/resources.py
@@ -1,0 +1,103 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific
+'''resources.py'''
+import glob
+import shutil
+
+from heron.proto import topology_pb2
+import heron.cli.src.python.execute as execute
+import heron.cli.src.python.jars as jars
+import heron.cli.src.python.args as cli_args
+import heron.cli.src.python.opts as opts
+import heron.cli.src.python.topology as topology
+import heron.common.src.python.utils.config as config
+
+def create_parser(subparsers):
+  '''
+  :param subparsers:
+  :return:
+  '''
+  parser = subparsers.add_parser(
+      'resources',
+      help='Provides information about the resources required to schedule the topology',
+      usage="%(prog)s [options] " + \
+            "topology-file-name topology-class-name [topology-args]",
+      add_help=False
+  )
+
+  cli_args.add_titles(parser)
+  cli_args.add_cluster_role_env(parser)
+  cli_args.add_topology_file(parser)
+  cli_args.add_topology_class(parser)
+  cli_args.add_system_property(parser)
+  cli_args.add_config(parser)
+  cli_args.add_verbose(parser)
+
+  parser.set_defaults(subcommand='resources')
+  return parser
+
+# pylint: disable=unused-argument
+def run(command, parser, cl_args, unknown_args):
+  '''
+  :param command:
+  :param parser:
+  :param cl_args:
+  :param unknown_args:
+  :return:
+  '''
+  topology_file = cl_args['topology-file-name']
+  topology_class = cl_args['topology-class-name']
+  jvm_properties = cl_args['topology_main_jvm_property']
+
+  initial_state = topology_pb2.TopologyState.Name(topology_pb2.RUNNING)
+  defn_dir = topology.generate_definition(topology_file, topology_class, jvm_properties,
+                                          unknown_args, initial_state)
+
+  try:
+    defn_files = glob.glob(defn_dir + '/*.defn')
+
+    if len(defn_files) == 0:
+      raise Exception("No topologies found")
+
+    for defn_file in defn_files:
+      # load the topology definition from the file
+      topology_defn = topology_pb2.Topology()
+
+      handle = open(defn_file, "rb")
+      topology_defn.ParseFromString(handle.read())
+      handle.close()
+
+      release_yaml_file = config.get_heron_release_file()
+      new_args = [
+          "--config_path", cl_args['config_path'],
+          "--heron_home", config.get_heron_dir(),
+          "--override_config_file", cl_args['override_config_file'],
+          "--topology_defn", defn_file,
+          "--release_file", release_yaml_file,
+      ]
+
+      if opts.verbose():
+        new_args.append("--verbose")
+
+      lib_jars = config.get_heron_libs(
+          jars.scheduler_jars() + jars.statemgr_jars() + jars.packing_jars()
+      )
+
+      execute.heron_class('com.twitter.heron.scheduler.ResourcesMain',
+                          lib_jars,
+                          extra_jars=[],
+                          args=new_args)
+  finally:
+    shutil.rmtree(defn_dir)
+
+  return True

--- a/heron/cli/src/python/topology.py
+++ b/heron/cli/src/python/topology.py
@@ -1,0 +1,40 @@
+# Copyright 2016 Twitter. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# !/usr/bin/env python2.7
+''' topology.py '''
+import tempfile
+
+import heron.cli.src.python.execute as execute
+import heron.cli.src.python.jars as jars
+import heron.cli.src.python.opts as opts
+import heron.common.src.python.utils.config as config
+
+def generate_definition(topology_file, topology_class, jvm_properties, args, initial_state):
+  tmp_dir = tempfile.mkdtemp()
+
+  # set the tmp dir and deactivated state in global options
+  opts.set_config('cmdline.topologydefn.tmpdirectory', tmp_dir)
+  opts.set_config('cmdline.topology.initial.state', initial_state)
+
+  try:
+    execute.heron_class(topology_class,
+                        config.get_heron_libs(jars.topology_jars()),
+                        extra_jars=[topology_file],
+                        args=tuple(args),
+                        java_defines=jvm_properties)
+  except Exception as err:
+    raise Exception("Unable to execute topology main class {0}".format(err))
+
+  return tmp_dir

--- a/heron/scheduler-core/src/java/BUILD
+++ b/heron/scheduler-core/src/java/BUILD
@@ -4,6 +4,7 @@ load("/tools/rules/heron_deps", "heron_java_proto_files")
 
 common_deps_files = [
    "//heron/common/src/java:common-java",
+   "//third_party/java:jackson",
    "@commons_cli_commons_cli//jar",
    "@com_google_guava_guava//jar",
 ]

--- a/heron/scheduler-core/src/java/com/twitter/heron/scheduler/ResourcesMain.java
+++ b/heron/scheduler-core/src/java/com/twitter/heron/scheduler/ResourcesMain.java
@@ -1,0 +1,283 @@
+// Copyright 2016 Twitter. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.twitter.heron.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.twitter.heron.api.generated.TopologyAPI;
+import com.twitter.heron.spi.common.ClusterConfig;
+import com.twitter.heron.spi.common.ClusterDefaults;
+import com.twitter.heron.spi.common.Config;
+import com.twitter.heron.spi.common.Context;
+import com.twitter.heron.spi.common.Keys;
+import com.twitter.heron.spi.packing.IPacking;
+import com.twitter.heron.spi.packing.PackingPlan;
+import com.twitter.heron.spi.packing.Resource;
+import com.twitter.heron.spi.utils.ReflectionUtils;
+import com.twitter.heron.spi.utils.TopologyUtils;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+public class ResourcesMain {
+  private static final Logger LOG = Logger.getLogger(ResourcesMain.class.getName());
+
+  public static void main(String... args) throws ParseException {
+    // construct the options and help options first.
+    Options options = constructOptions();
+    Options helpOptions = constructHelpOptions();
+
+    // parse the options
+    CommandLineParser parser = new DefaultParser();
+    CommandLine cmd = parser.parse(helpOptions, args, true);
+
+    // print help, if we receive wrong set of arguments
+    if (cmd.hasOption("h")) {
+      usage(options);
+      return;
+    }
+
+    // Now parse the required options
+    try {
+      cmd = parser.parse(options, args);
+    } catch (ParseException e) {
+      usage(options);
+      throw new RuntimeException("Error parsing command line options: ", e);
+    }
+
+    Boolean verbose = cmd.hasOption("v");
+    String cluster = cmd.getOptionValue("cluster");
+    String role = cmd.getOptionValue("role");
+    String environment = cmd.getOptionValue("environment");
+    String topologyDefnFile = cmd.getOptionValue("topology_defn");
+    String heronHome = cmd.getOptionValue("heron_home");
+    String configPath = cmd.getOptionValue("config_path");
+    String overrideConfigFile = cmd.getOptionValue("override_config_file");
+    String releaseFile = cmd.getOptionValue("release_file");
+    TopologyAPI.Topology topology = TopologyUtils.getTopology(topologyDefnFile);
+
+    Config config = Config.newBuilder()
+            .putAll(defaultConfigs(heronHome, configPath, releaseFile))
+            .putAll(overrideConfigs(overrideConfigFile))
+            .putAll(commandLineConfigs(cluster, role, environment, verbose))
+            .putAll(topologyConfigs(topologyDefnFile, topology))
+            .build();
+
+    String packingClass = Context.packingClass(config);
+    IPacking packing;
+    try {
+      // create an instance of the packing class
+      packing = ReflectionUtils.newInstance(packingClass);
+
+      Config runtime = Config.newBuilder()
+          .put(Keys.topologyId(), topology.getId())
+          .put(Keys.topologyName(), topology.getName())
+          .put(Keys.topologyDefinition(), topology)
+          .put(Keys.numContainers(), 1 + TopologyUtils.getNumContainers(topology))
+          .build();
+
+      packing.initialize(config, runtime);
+      PackingPlan plan = packing.pack();
+
+      System.out.println(formatContainerResources(topology.getName() ,plan));
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Failed to instantiate instances", e);
+    }
+  }
+
+  static String formatContainerResources(String topologyName, PackingPlan packingPlan) throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+
+    ObjectNode rootNode = mapper.createObjectNode();
+    ObjectNode containerNode = mapper.createObjectNode();
+    ObjectNode totalsNode = mapper.createObjectNode();
+
+    rootNode.put("topology_name", topologyName);
+
+    totalsNode.put("cpu", packingPlan.resource.cpu);
+    totalsNode.put("ram", packingPlan.resource.ram);
+    totalsNode.put("disk", packingPlan.resource.disk);
+
+    for (Map.Entry<String, PackingPlan.ContainerPlan> entry : packingPlan.containers.entrySet()) {
+      String containerId = entry.getKey();
+      PackingPlan.ContainerPlan containerPlan = entry.getValue();
+      Resource resources = containerPlan.resource;
+
+      ObjectNode containerResources = mapper.createObjectNode();
+      containerResources.put("cpu", resources.cpu);
+      containerResources.put("ram", resources.ram);
+      containerResources.put("disk", resources.disk);
+
+      containerNode.putPOJO(containerId, containerResources);
+    }
+
+    rootNode.putPOJO("containers", containerNode);
+    rootNode.putPOJO("totals", totalsNode);
+
+    return mapper.writeValueAsString(rootNode);
+  }
+
+  /**
+   * Load the topology config
+   *
+   * @param topology, proto in memory version of topology definition
+   * @return config, the topology config
+   */
+  protected static Config topologyConfigs(String topologyDefnFile,
+      TopologyAPI.Topology topology) {
+
+    return Config.newBuilder()
+        .put(Keys.topologyId(), topology.getId())
+        .put(Keys.topologyName(), topology.getName())
+        .put(Keys.topologyDefinitionFile(), topologyDefnFile)
+        .build();
+  }
+
+  /**
+   * Load the defaults config
+   *
+   * @param heronHome, directory of heron home
+   * @param configPath, directory containing the config
+   * @param releaseFile, release file containing build information
+   * <p>
+   * return config, the defaults config
+   */
+  protected static Config defaultConfigs(String heronHome, String configPath, String releaseFile) {
+    return Config.newBuilder()
+        .putAll(ClusterDefaults.getDefaults())
+        .putAll(ClusterDefaults.getSandboxDefaults())
+        .putAll(ClusterConfig.loadConfig(heronHome, configPath, releaseFile))
+        .build();
+  }
+
+  /**
+   * Load the override config from cli
+   *
+   * @param overrideConfigPath, override config file path
+   * <p>
+   * @return config, the override config
+   */
+  protected static Config overrideConfigs(String overrideConfigPath) {
+    return Config.newBuilder()
+        .putAll(ClusterConfig.loadOverrideConfig(overrideConfigPath))
+        .build();
+  }
+
+  /**
+   * Load the config parameters from the command line
+   *
+   * @param cluster, name of the cluster
+   * @param role, user role
+   * @param environ, user provided environment/tag
+   * @param verbose, enable verbose logging
+   * @return config, the command line config
+   */
+  protected static Config commandLineConfigs(String cluster,
+                                             String role,
+                                             String environ,
+                                             Boolean verbose) {
+
+    return Config.newBuilder()
+        .put(Keys.cluster(), cluster)
+        .put(Keys.role(), role)
+        .put(Keys.environ(), environ)
+        .put(Keys.verbose(), verbose)
+        .build();
+  }
+
+
+    // Construct all required command line options
+  private static Options constructOptions() {
+    Options options = new Options();
+
+    Option topologyDefn = Option.builder("n")
+        .desc("Name of the topology")
+        .longOpt("topology_defn")
+        .hasArgs()
+        .argName("topology definition file")
+        .required()
+        .build();
+
+    Option configFile = Option.builder("p")
+        .desc("Path of the config files")
+        .longOpt("config_path")
+        .hasArgs()
+        .argName("config path")
+        .build();
+
+    Option heronHome = Option.builder("h")
+        .desc("Path to heron home")
+        .longOpt("heron_home")
+        .hasArgs()
+        .argName("heron home")
+        .build();
+
+    Option overrideConfigFile = Option.builder("c")
+        .desc("override config file")
+        .longOpt("override_config_file")
+        .hasArgs()
+        .argName("override config file")
+        .build();
+
+    Option releaseFile = Option.builder("r")
+        .desc("release_file")
+        .longOpt("release_file")
+        .hasArgs()
+        .argName("release file")
+        .build();
+
+    Option verbose = Option.builder("v")
+        .desc("Enable debug logs")
+        .longOpt("verbose")
+        .build();
+
+    options.addOption(topologyDefn);
+    options.addOption(configFile);
+    options.addOption(heronHome);
+    options.addOption(releaseFile);
+    options.addOption(overrideConfigFile);
+    options.addOption(verbose);
+
+    return options;
+  }
+
+    // construct command line help options
+  private static Options constructHelpOptions() {
+    Options options = new Options();
+    Option help = Option.builder("h")
+        .desc("List all options and their description")
+        .longOpt("help")
+        .build();
+
+    options.addOption(help);
+    return options;
+  }
+
+  // Print usage options
+  private static void usage(Options options) {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp("ResourcesMain", options);
+  }
+}


### PR DESCRIPTION
This will print the resources for the topology out to the console in
json format. Note that heron will output all of its log mesages on
stderr but this command will output only the json blob on stdout so it
can be easily consumed.

Usage is:
```
heron resources <env> <path-to-jar> <main-class>

{"containers":{"11":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"1":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"12":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"2":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"3":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"4":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"5":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"6":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"7":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"8":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"9":{"cpu":2.0,"ram":9114222592,"disk":18253611008},"10":{"cpu":2.0,"ram":9114222592,"disk":18253611008}},"totals":{"cpu":26.0,"ram":118484893696,"disk":237296943104}}
```